### PR TITLE
Set default :shared_file_dir to main shared_path

### DIFF
--- a/lib/capistrano/shared_file.rb
+++ b/lib/capistrano/shared_file.rb
@@ -15,9 +15,10 @@ if Capistrano::Configuration.instance
 
     # ================================================================
     # These variables define where to store the shared files.
+    # Defaults to the main 'shared_path' location.
     # Make sure you understand the implication when you modify them.
     # ================================================================
-    _cset :shared_file_dir, "files"
+    _cset :shared_file_dir, ""
     _cset(:shared_file_path) { File.join(shared_path, shared_file_dir).sub(/#{File::SEPARATOR}$/,'') }
 
 


### PR DESCRIPTION
- Remove 'files' subdirectory within shared_path as default option
- Extra documentation to inform users about default value

This commit fixes #5
